### PR TITLE
fix: wrap `Date` methods to keep `this` reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## 0.2.1 - 2022/02/08
+
+- ([#58](https://github.com/alchemauss/mauss/pull/58)) fix `TypeError` in `dt.format` not having reference to `this`
+
 ## 0.2.0 - 2022/02/08
 
 - ([#57](https://github.com/alchemauss/mauss/pull/57)) augmenting `guards` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # mauss changelog
 
-## 0.2.1 - 2022/02/08
+## Unreleased
 
 - ([#58](https://github.com/alchemauss/mauss/pull/58)) fix `TypeError` in `dt.format` not having reference to `this`
 

--- a/src/utils/temporal/masks.ts
+++ b/src/utils/temporal/masks.ts
@@ -23,13 +23,13 @@ type MaskOptions = { date: Date; base?: 'UTC' };
 export default ({ date, base }: MaskOptions): Record<MaskToken, () => string> => {
 	const method = base === 'UTC' ? 'getUTC' : 'get';
 	const now = {
-		date: date[`${method}Date`],
-		day: date[`${method}Day`],
-		month: date[`${method}Month`],
-		year: date[`${method}FullYear`],
-		hours: date[`${method}Hours`],
-		minutes: date[`${method}Minutes`],
-		seconds: date[`${method}Seconds`],
+		date: () => date[`${method}Date`](),
+		day: () => date[`${method}Day`](),
+		month: () => date[`${method}Month`](),
+		year: () => date[`${method}FullYear`](),
+		hours: () => date[`${method}Hours`](),
+		minutes: () => date[`${method}Minutes`](),
+		seconds: () => date[`${method}Seconds`](),
 		tzo: base === 'UTC' ? 0 : date.getTimezoneOffset(),
 	};
 


### PR DESCRIPTION
I've been bitten by this once with `api`, why did I fall to the same hole twice