### PR TITLE
feat: super compact tz offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+- ([#59](https://github.com/alchemauss/mauss/pull/59)) add super compact tz offset, allowing from 1 up to 3 `Z`s
 - ([#58](https://github.com/alchemauss/mauss/pull/58)) fix `TypeError` in `dt.format` not having reference to `this`
+
+### Notes
+
+- [#59](https://github.com/alchemauss/mauss/pull/59) | Allow `Z` to be defined from 1 up to 3 times in `dt.format` mask, with `Z` only showing the hour without padded zeros
 
 ## 0.2.0 - 2022/02/08
 

--- a/src/utils/temporal/index.ts
+++ b/src/utils/temporal/index.ts
@@ -25,7 +25,7 @@ export const dt = {
 		const tokens = tokenizer({ date, base });
 
 		return mask.replace(
-			/D{1,4}|M{1,4}|YY(?:YY)?|([hHmsAPap])\1?|Z{1,2}|\[([^\]\[]|\[[^\[\]]*\])*\]/g,
+			/D{1,4}|M{1,4}|YY(?:YY)?|([hHmsAPap])\1?|Z{1,3}|\[([^\]\[]|\[[^\[\]]*\])*\]/g,
 			($) => ($ in tokens ? tokens[$ as keyof typeof tokens]() : $.slice(1, $.length - 1))
 		);
 	},

--- a/src/utils/temporal/masks.ts
+++ b/src/utils/temporal/masks.ts
@@ -34,13 +34,12 @@ export default ({ date, base }: MaskOptions): Record<MaskToken, () => string> =>
 	};
 
 	const marker = () => (now.hours() < 12 ? 'AM' : 'PM');
-	const timezone = (colon = '') => {
-		const sign = now.tzo > 0 ? '-' : '+';
+	const timezone = () => {
 		const abs = Math.abs(now.tzo);
-		const h = p(Math.floor(abs / 60));
-		const m = p(abs % 60);
-		return `${sign}${h}${colon}${m}`;
+		return { h: Math.floor(abs / 60), m: abs % 60 };
 	};
+
+	const sign = now.tzo > 0 ? '-' : '+';
 
 	return {
 		D: () => s(now.date()),
@@ -65,8 +64,15 @@ export default ({ date, base }: MaskOptions): Record<MaskToken, () => string> =>
 		p: marker,
 		A: marker,
 		P: marker,
-		Z: () => timezone(),
-		ZZ: () => timezone(':'),
+		Z: () => `${sign}${timezone().h}`,
+		ZZ: () => {
+			const { h, m } = timezone();
+			return `${sign}${p(h)}${p(m)}`;
+		},
+		ZZZ: () => {
+			const { h, m } = timezone();
+			return `${sign}${p(h)}:${p(m)}`;
+		},
 	};
 };
 
@@ -79,7 +85,7 @@ type TokenSeconds = 's' | 'ss';
 /** time marker, AM / PM */
 type TokenMarker = 'a' | 'p' | 'A' | 'P';
 /** timezone offset */
-type TokenOffset = 'Z' | 'ZZ';
+type TokenOffset = 'Z' | 'ZZ' | 'ZZZ';
 type MaskToken =
 	| TokenDays
 	| TokenMonths

--- a/src/utils/temporal/masks.ts
+++ b/src/utils/temporal/masks.ts
@@ -36,7 +36,7 @@ export default ({ date, base }: MaskOptions): Record<MaskToken, () => string> =>
 	const marker = () => (now.hours() < 12 ? 'AM' : 'PM');
 	const timezone = () => {
 		const abs = Math.abs(now.tzo);
-		return { h: Math.floor(abs / 60), m: abs % 60 };
+		return [Math.floor(abs / 60), abs % 60];
 	};
 
 	const sign = now.tzo > 0 ? '-' : '+';
@@ -64,13 +64,13 @@ export default ({ date, base }: MaskOptions): Record<MaskToken, () => string> =>
 		p: marker,
 		A: marker,
 		P: marker,
-		Z: () => `${sign}${timezone().h}`,
+		Z: () => `${sign}${timezone()[0]}`,
 		ZZ: () => {
-			const { h, m } = timezone();
+			const [h, m] = timezone();
 			return `${sign}${p(h)}${p(m)}`;
 		},
 		ZZZ: () => {
-			const { h, m } = timezone();
+			const [h, m] = timezone();
 			return `${sign}${p(h)}:${p(m)}`;
 		},
 	};


### PR DESCRIPTION
This should be considered a breaking change, but `dt.format` isn't even usable before, so we're not technically breaking anything