### PR TITLE
fix: generated types for `dt` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## Unreleased
+
+- fix `new` property getting mixed-up as constructor for `dt`
+
 ## 0.2.1 - 2022/02/09
 
 - ([#59](https://github.com/alchemauss/mauss/pull/59)) add super compact tz offset, allowing from 1 up to 3 `Z`s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix `new` property getting mixed-up as constructor for `dt`
+- ([#60](https://github.com/alchemauss/mauss/pull/60)) fix `new` property getting mixed-up as constructor for `dt`
 
 ## 0.2.1 - 2022/02/09
 

--- a/src/utils/temporal/index.ts
+++ b/src/utils/temporal/index.ts
@@ -12,7 +12,7 @@ export const dt = {
 	get now() {
 		return new Date();
 	},
-	new(d?: DateValue) {
+	new: function (d?: DateValue) {
 		if (d instanceof Date) return d;
 		return d ? new Date(d) : this.now;
 	},


### PR DESCRIPTION
Using it directly in the `.ts` file works and gives out all the autocompletion as expected, but the generated types seems to be getting mixed-up and sees `new` as a constructor.