### PR TITLE
feat: remove deprecated `svelteBracketNewLine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## Unreleased
+
+- ([#64](https://github.com/alchemauss/mauss/pull/64)) remove `svelteBracketNewLine` option from prettier config
+
 ## 0.2.2 - 2022/02/11
 
 - ([#61](https://github.com/alchemauss/mauss/pull/61)) fix mismatched `unique` return type

--- a/prettier.json
+++ b/prettier.json
@@ -24,7 +24,6 @@
 			"options": {
 				"svelteSortOrder": "options-scripts-markup-styles",
 				"svelteStrictMode": false,
-				"svelteBracketNewLine": true,
 				"svelteAllowShorthand": true,
 				"svelteIndentScriptAndStyle": true
 			}

--- a/prettier.json
+++ b/prettier.json
@@ -31,7 +31,7 @@
 		{
 			"files": ["*.y*ml"],
 			"options": {
-				"singleQuote": false
+				"useTabs": false
 			}
 		}
 	]

--- a/prettier.json
+++ b/prettier.json
@@ -31,7 +31,7 @@
 		{
 			"files": ["*.y*ml"],
 			"options": {
-				"useTabs": false
+				"singleQuote": false
 			}
 		}
 	]


### PR DESCRIPTION
Technically not a breaking change since the default value is `true`, and the corresponding `bracketSameLine` has a default value of `false`, which behaves the same way as the current option.