### PR TITLE
feat: type-safe `pipe` higher-order function

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,4 @@
-import type { AnyFunction, Reverse } from '../typings';
+import type { AnyFunction, Last, Reverse, UnaryFunction } from '../typings';
 
 /**
  * inverse - reverses the order of provided arguments to fn parameters
@@ -7,6 +7,19 @@ import type { AnyFunction, Reverse } from '../typings';
  */
 export function inverse<T extends AnyFunction>(fn: T): AnyFunction<Reverse<Parameters<T>>> {
 	return (...parameters) => fn(...parameters.reverse());
+}
+
+// TODO: validate the next parameter receive the same return type as the previous
+export function pipe<Functions extends UnaryFunction[]>(...functions: Functions) {
+	type InitialType = Parameters<Functions[0]>[0];
+	type FinalType = ReturnType<Last<Functions, any>>;
+	return (arg: InitialType): FinalType => {
+		let pipeline = arg;
+		for (let i = 0; i < functions.length; i++) {
+			pipeline = functions[i](pipeline);
+		}
+		return pipeline;
+	};
 }
 
 /**

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -18,6 +18,8 @@ export type Reverse<T extends any[]> = T extends [infer H, ...infer R] ? [...Rev
 /** Strict properties narrowing and remove Index Signatures */
 export type Strict<T> = { [P in keyof T as {} extends Record<P, any> ? never : P]: T[P] };
 export type Typify<T> = { [P in keyof T]: Typify<T[P]> };
+/** Any function that has exactly one parameter */
+export type UnaryFunction<P = any, R = any> = (parameter: P) => R;
 
 /* <-- Type Level Programming --> */
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -4,10 +4,13 @@ export type AnyFunction<P extends any[] = any, R = any> = (...parameters: P) => 
 export type Either<A, B> = Only<A, B> | Only<B, A>;
 export type Entries<T> = Array<{ [K in keyof T]: [keyof PickByValue<T, T[K]>, T[K]] }[keyof T]>;
 export type Filter<T, Validator> = T extends Validator ? T : never;
+/** Get the first item from an array, fallback defaults to `never` */
+export type First<T extends any[], Fallback = never> = T extends [infer F, ...any[]] ? F : Fallback;
 /** Allow autocompletion of union in addition to arbitrary values */
 export type Flexible<Union extends T, T = string> = Union | (T & Record<never, never>);
 /** Infers the return value of toJSON on the properties */
 export type JSONState<T> = { [P in keyof T]: T[P] extends { toJSON: () => infer J } ? J : T[P] };
+/** Get the last item from an array, fallback defaults to `never` */
 export type Last<T extends any[], Fallback = never> = T extends [...any[], infer L] ? L : Fallback;
 export type NonEmptyArray<T> = [T, ...Array<T>];
 /** Disallow any properties from V when defining U */

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -8,6 +8,7 @@ export type Filter<T, Validator> = T extends Validator ? T : never;
 export type Flexible<Union extends T, T = string> = Union | (T & Record<never, never>);
 /** Infers the return value of toJSON on the properties */
 export type JSONState<T> = { [P in keyof T]: T[P] extends { toJSON: () => infer J } ? J : T[P] };
+export type Last<T extends any[], Fallback = never> = T extends [...any[], infer L] ? L : Fallback;
 export type NonEmptyArray<T> = [T, ...Array<T>];
 /** Disallow any properties from V when defining U */
 export type Only<U, V> = { [P in keyof U]: U[P] } & Omit<{ [P in keyof V]?: never }, keyof U>;


### PR DESCRIPTION
Closes #71 