### PR TITLE
chore: add `./typings` to `exports` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## Unreleased
+
+- ([#134](https://github.com/alchemauss/mauss/pull/134)) add `./typings` to `exports` field
+
 ## 0.3.1 - 2022/07/27
 
 - ([#131](https://github.com/alchemauss/mauss/pull/131)) support native ESM resolution

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "./utils": "./utils/index.js",
     "./utils/toolbox": "./utils/toolbox.js",
     "./web": "./web/index.js",
+    "./typings": "./typings/index.d.ts",
     "./package.json": "./package.json",
     "./prettier.json": "./prettier.json",
     "./tsconfig.json": "./tsconfig.json"


### PR DESCRIPTION
Fixes #133 