### PR TITLE
chore: release without git checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,6 @@ jobs:
           node-version: 16
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install
-      - run: pnpm publish
+      - run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Published v0.4.0 manually for now since it failed in 386a642513d94d66e7641677c9ce9b7e4c90e039, we don't need to check before publishing from workflows.