### PR TITLE
feat: implement `tsf` to `/std`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## Unreleased
+
+- ([#221](https://github.com/alchemauss/mauss/pull/221)) add `tsf` function to `/std` module
+
 ## 0.4.11 - 2023/03/30
 
 - ([#216](https://github.com/alchemauss/mauss/pull/216)) remove deprecated option for TS 5.0

--- a/src/std/README.md
+++ b/src/std/README.md
@@ -98,7 +98,11 @@ A template string function. This takes a template string and returns a function 
 This assumes the braces inside the template string are balanced and not nested. The function will not throw an error if the braces are not balanced, but the result will be unexpected. If you're using TypeScript and are passing a [string literal](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), it will point out any unbalanced braces by throwing an error from the compiler.
 
 ```typescript
-export function tsf(template: string): (table: Record<string, (v: string) => string>) => string;
+export function tsf(
+  template: string
+): (table: {
+  [key: string]: string | false | Nullish | ((key: string) => string | false | Nullish);
+}) => string;
 ```
 
 The template string is parsed into an array of strings, which are then executed with the provided table of functions, which is an object with the key being the name of the braces from the template string, and the value being the function to manipulate the name of the braces.
@@ -109,9 +113,10 @@ import { tsf } from 'mauss/std';
 const render = tsf('https://api.example.com/v1/{category}/{id}');
 
 function publish({ category, id }) {
+  const prefix = // ...
   const url = render({
-    category: () => category,
-    id: (v) => `${v}-${id}`,
+    category: () => category !== 'new' && category,
+    id: (v) => prefix + uuid(`${v}-${id}`),
   });
 
   return fetch(url);

--- a/src/std/README.md
+++ b/src/std/README.md
@@ -90,3 +90,30 @@ Original function, aggregates elements from each of the arrays and returns a sin
 ```typescript
 export function zip<T extends Array<Nullish | {}>>(...arrays: T[]): Record<IndexSignature, any>[];
 ```
+
+## `tsf`
+
+A template string function. This takes a template string and returns a function that takes an object of functions, which is used to manipulate the name of the braces in the template string.
+
+This assumes the braces inside the template string are balanced and not nested. The function will not throw an error if the braces are not balanced, but the result will be unexpected. If you're using TypeScript and are passing a [string literal](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), it will point out any unbalanced braces by throwing an error from the compiler.
+
+```typescript
+export function tsf(template: string): (table: Record<string, (v: string) => string>) => string;
+```
+
+The template string is parsed into an array of strings, which are then executed with the provided table of functions, which is an object with the key being the name of the braces from the template string, and the value being the function to manipulate the name of the braces.
+
+```javascript
+import { tsf } from 'mauss/std';
+
+const render = tsf('https://api.example.com/v1/{category}/{id}');
+
+function publish({ category, id }) {
+  const url = render({
+    category: () => category,
+    id: (v) => `${v}-${id}`,
+  });
+
+  return fetch(url);
+}
+```

--- a/src/std/index.ts
+++ b/src/std/index.ts
@@ -1,2 +1,3 @@
 export * as csv from './csv/index.js';
 export * as ntv from './ntv/index.js';
+export { tsf } from './tsf/index.js';

--- a/src/std/tsf/index.spec.ts
+++ b/src/std/tsf/index.spec.ts
@@ -1,0 +1,50 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { tsf } from './index.js';
+
+test.skip('throws on nested braces', () => {
+	assert.throws(() => tsf('/{foo/{bar}}' as string));
+	assert.throws(() => tsf('/{nested-{}-braces}' as string));
+});
+
+test('parses template without braces', () => {
+	assert.equal(tsf('')({}), '');
+	assert.equal(tsf('/')({}), '/');
+	assert.equal(tsf('/foo')({}), '/foo');
+});
+
+test('parses template correctly', () => {
+	const r1 = tsf('/{foo}/{bar}');
+
+	assert.equal(
+		r1({
+			foo: 'hello',
+			bar: 'world',
+		}),
+		'/hello/world'
+	);
+	assert.equal(
+		r1({
+			foo: (v) => v,
+			bar: (v) => v,
+		}),
+		'/foo/bar'
+	);
+	assert.equal(
+		r1({
+			foo: (v) => [...v].reverse().join(''),
+			bar: (v) => [...v].reverse().join(''),
+		}),
+		'/oof/rab'
+	);
+});
+
+test.skip('parses template with nested braces', () => {
+	const r1 = tsf('/{foo/{bar}}' as string);
+	assert.equal(r1({ 'foo/{bar}': (v) => v }), '/foo/{bar}');
+
+	const r2 = tsf('/{nested-{}-braces}' as string);
+	assert.equal(r2({ 'nested-{}-braces': (v) => v }), '/nested-{}-braces');
+});
+
+test.run();

--- a/src/std/tsf/index.test.ts
+++ b/src/std/tsf/index.test.ts
@@ -1,0 +1,51 @@
+import { tsf } from './index.js';
+
+tsf('');
+tsf('/');
+tsf('/')({});
+tsf('/{foo}')({ foo: (v) => v });
+tsf('/{foo}/{bar}')({ foo: 'hello', bar: () => 'world' });
+tsf('/{foo}/{bar}')({ foo: (v) => v, bar: (v) => v });
+tsf('/{foo}')({ foo: (v) => v.length > 1 && v.replace('o', 'u') });
+tsf('' as string)({ boo: (v) => v });
+tsf('' as `${string}/v1/posts/{id}/comments`)({ id: (v) => v });
+
+// ---- errors ----
+
+// @ts-expect-error
+tsf('{}');
+// @ts-expect-error
+tsf('/{}');
+// @ts-expect-error
+tsf('{}/');
+// @ts-expect-error
+tsf('/{{}}');
+// @ts-expect-error
+tsf('/{}}');
+// @ts-expect-error
+tsf('/{{}');
+// @ts-expect-error
+tsf('/{{}{');
+// @ts-expect-error
+tsf('/{{foo}}');
+// @ts-expect-error
+tsf('/{{foo}{');
+// @ts-expect-error
+tsf('/{}/{bar}');
+// @ts-expect-error
+tsf('/{foo}/{{}}');
+
+// @ts-expect-error
+tsf('/')();
+// @ts-expect-error
+tsf('/{foo}')();
+// @ts-expect-error
+tsf('/{foo}/{bar}')({});
+// @ts-expect-error
+tsf('/{foo}/{bar}')({ foo: (v) => v });
+// @ts-expect-error
+tsf('/{foo}')({ foo: (v) => v, bar: (v) => v });
+// @ts-expect-error
+tsf('' as `${string}/v1/posts/{id}/comments`)({});
+
+tsf('{hello-world}')({ 'hello-world': (v) => v });

--- a/src/std/tsf/index.ts
+++ b/src/std/tsf/index.ts
@@ -1,0 +1,47 @@
+import { Nullish } from '../../typings/aliases.js';
+import { UnaryFunction } from '../../typings/helpers.js';
+
+type Parse<T> = T extends `${string}{${infer P}}${infer R}` ? P | Parse<R> : never;
+export function tsf<Input extends string>(
+	template: Input extends
+		| `${string}{}${string}`
+		| `${string}{{${string}}}${string}`
+		| `${string}{{${string}}${string}`
+		| `${string}{${string}}}${string}`
+		? never
+		: Input
+) {
+	const parts: string[] = [];
+	for (let i = 0, start = 0; i < template.length; i += 1) {
+		if (template[i] === '{') {
+			if (i > start) parts.push(template.slice(start, i));
+
+			const end = template.indexOf('}', i);
+			if (end === -1 /** missing closing */) {
+				parts.push(template.slice(i));
+				break;
+			}
+
+			parts.push(template.slice(i + 1, end));
+			start = (i = end) + 1;
+		} else if (i === template.length - 1) {
+			parts.push(template.slice(start));
+		}
+	}
+
+	type ConditionalString = string | false | Nullish;
+	type Replacer = ConditionalString | UnaryFunction<string, ConditionalString>;
+	type ExpectedProperties = string extends Input ? string : Parse<Input>;
+	return function render(table: { [K in ExpectedProperties]: Replacer }) {
+		let transformed = '';
+		for (let i = 0; i < parts.length; i += 1) {
+			const replace = table[parts[i] as ExpectedProperties];
+			if (typeof replace === 'function') {
+				transformed += replace(parts[i]) || '';
+			} else {
+				transformed += replace || parts[i];
+			}
+		}
+		return transformed;
+	};
+}


### PR DESCRIPTION
We're using a for-loop instead of built-in methods like split and regex as this offers several advantages, most importantly increased efficiency for larger strings. Running a benchmark with `"perf_hooks"` and `1e6` iterations, we can see one of the results, which is
```sql
rgx-split: 284.800822ms
for-loop : 120.172763ms
```