### PR TITLE
feat: remove `create` from `ntv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mauss changelog
 
+## 0.5.0 - Unreleased
+
+- ([#223](https://github.com/alchemauss/mauss/pull/223)) remove `create` from `ntv` namespace
+
 ## 0.4.12 - 2023/05/02
 
 - ([#224](https://github.com/alchemauss/mauss/pull/224)) add string guards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - ([#223](https://github.com/alchemauss/mauss/pull/223)) remove `create` from `ntv` namespace
 
+### Breaking Changes
+
+- [#223](https://github.com/alchemauss/mauss/pull/223) | Removed `create` from `ntv` namespace, use array `.reduce` instead
+
 ## 0.4.12 - 2023/05/02
 
 - ([#224](https://github.com/alchemauss/mauss/pull/224)) add string guards

--- a/src/std/README.md
+++ b/src/std/README.md
@@ -35,14 +35,6 @@ export function clone<T>(i: T): T;
 
 Creating a copy of a data type, especially an object, is useful for removing the reference to the original object, keeping it clean from unexpected changes and side effects. This is possible because we are creating a new instance, making sure that any mutation or changes that are applied won't affect one or the other.
 
-### `ntv.create`
-
-```typescript
-export function create<T>(array: T[], i: any): { [K in T]: typeof i };
-```
-
-Create an object with keys from an array of strings with the option to specify the initial value, defaulting to `null`.
-
 ### `ntv.freeze`
 
 Augmented `Object.freeze()`, deep freezes and strongly-typed.

--- a/src/std/ntv/object.spec.ts
+++ b/src/std/ntv/object.spec.ts
@@ -5,7 +5,6 @@ import * as ntv from './object.js';
 
 const basics = {
 	clone: suite('obj:clone'),
-	create: suite('obj:create'),
 	entries: suite('obj:entries'),
 	freeze: suite('obj:freeze'),
 	iterate: suite('obj:iterate'),
@@ -26,13 +25,6 @@ basics.clone('clone any possible data type', () => {
 	assert.equal(base.obj, cloned.obj);
 	assert.equal(base.arr[2], cloned.arr[2]);
 	assert.equal(base.obj.now, cloned.obj.now);
-});
-
-basics.create('create object from an array', () => {
-	const numbers = ntv.create([1, 2, 0]);
-	assert.equal(numbers, { 1: null, 2: null, 0: null });
-	const vowels = ntv.create(['a', 'i', 'u', 'e', 'o'], '');
-	assert.equal(vowels, { a: '', i: '', u: '', e: '', o: '' });
 });
 
 basics.entries('return object entries', () => {

--- a/src/std/ntv/object.ts
+++ b/src/std/ntv/object.ts
@@ -10,12 +10,6 @@ export function clone<T>(i: T): T {
 	return iterate(i) as T;
 }
 
-export function create<T extends IndexSignature>(array: T[], i: any = null) {
-	const object = {} as { [K in T]: typeof i };
-	for (const key of array) object[key] = i;
-	return object;
-}
-
 export function entries<T extends object>(o: T) {
 	return Object.entries(o) as Entries<T>;
 }


### PR DESCRIPTION
Removed `create` from `ntv` namespace, use array `.reduce` instead

Supersedes and closes #219 
Closes #220 