### PR TITLE
fix: set `"module"` to `"Node16"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"check:style": "prettier -c . --plugin=prettier-plugin-sort-package-json",
 		"test": "pnpm test:unit",
 		"test:unit": "uvu -r tsm src \"(spec\\.ts)\"",
-		"pub:build": "tsc --project src",
+		"pub:build": "tsc --project src --declaration",
 		"pub:format": "prettier -wu **/*.{d.ts,js}",
 		"prepublishOnly": "pnpm pub:build && pnpm pub:format"
 	},

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "fast and efficient type-safe SDK",
 	"repository": "github:alchemauss/mauss",
 	"author": "Ignatius Bagus",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"clean": "git add * && git clean -dfx -e node_modules",
@@ -32,7 +33,7 @@
 		"./prettier.json": "./prettier.json",
 		"./tsconfig.json": "./tsconfig.json"
 	},
-	"packageManager": "pnpm@8.6.11",
+	"packageManager": "pnpm@8.7.0",
 	"prettier": "./prettier.json",
 	"keywords": [
 		"zero-dependency",
@@ -50,11 +51,11 @@
 		"settings"
 	],
 	"devDependencies": {
-		"@types/node": "^20.4.4",
-		"prettier": "^3.0.0",
-		"prettier-plugin-sort-package-json": "^0.1.0",
+		"@types/node": "^20.5.7",
+		"prettier": "^3.0.2",
+		"prettier-plugin-sort-package-json": "^0.2.0",
 		"tsm": "^2.3.0",
-		"typescript": "^5.1.6",
+		"typescript": "^5.2.2",
 		"uvu": "^0.5.6"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,21 +1,25 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 devDependencies:
   '@types/node':
-    specifier: ^20.4.4
-    version: 20.4.4
+    specifier: ^20.5.7
+    version: 20.5.7
   prettier:
-    specifier: ^3.0.0
-    version: 3.0.0
+    specifier: ^3.0.2
+    version: 3.0.2
   prettier-plugin-sort-package-json:
-    specifier: ^0.1.0
-    version: 0.1.0(prettier@3.0.0)
+    specifier: ^0.2.0
+    version: 0.2.0(prettier@3.0.2)
   tsm:
     specifier: ^2.3.0
     version: 2.3.0
   typescript:
-    specifier: ^5.1.6
-    version: 5.1.6
+    specifier: ^5.2.2
+    version: 5.2.2
   uvu:
     specifier: ^0.5.6
     version: 0.5.6
@@ -40,8 +44,8 @@ packages:
     dev: true
     optional: true
 
-  /@types/node@20.4.4:
-    resolution: {integrity: sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==}
+  /@types/node@20.5.7:
+    resolution: {integrity: sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==}
     dev: true
 
   /dequal@2.0.3:
@@ -274,16 +278,16 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /prettier-plugin-sort-package-json@0.1.0(prettier@3.0.0):
-    resolution: {integrity: sha512-PE2/7Bls5A7rMH3Fvo/UnKNkj+fERmujhV4dP126djlpmwWrBBXk9ruJwLy//BX7dXjY8mffCbxH5/FUXCxpcw==}
+  /prettier-plugin-sort-package-json@0.2.0(prettier@3.0.2):
+    resolution: {integrity: sha512-jg+CfEHpmXyMJxoBSQh+IObmCxqt7KyHOuXGQm9D4heeyipEhlTJZfiS9SlfhBKrtf/yA8WZwHmynUG9xfF/rA==}
     peerDependencies:
       prettier: ^3.0.0
     dependencies:
-      prettier: 3.0.0
+      prettier: 3.0.2
     dev: true
 
-  /prettier@3.0.0:
-    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+  /prettier@3.0.2:
+    resolution: {integrity: sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -303,8 +307,8 @@ packages:
       esbuild: 0.15.18
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.json",
-	"compilerOptions": { "outDir": "..", "module": "Node16" },
+	"compilerOptions": { "outDir": ".." },
 	"exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.json",
-	"compilerOptions": { "outDir": "..", "declaration": true },
+	"compilerOptions": { "outDir": "..", "module": "Node16" },
 	"exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		// Project Options
 		"target": "ES2017",
-		"module": "ES2020",
+		"module": "Node16",
 		"checkJs": true,
 		"isolatedModules": true,
 


### PR DESCRIPTION
According to https://www.typescriptlang.org/tsconfig#node16nodenext-nightly-builds, `Node16` will use either `CommonJS` or `ES2020` output, which means there should be no noticeable difference for users with `"type": "module"` in their `package.json` file.