### PR TITLE
fix: export `sides` function

### DIFF
--- a/workspace/mauss/src/core/index.ts
+++ b/workspace/mauss/src/core/index.ts
@@ -2,6 +2,6 @@ export { curry, pipe } from './lambda/index.js';
 
 export { debounce, immediate, throttle } from './processor/index.js';
 
-export { capitalize, identical, inverse, regexp, scope, unique } from './standard/index.js';
+export { capitalize, identical, inverse, regexp, scope, sides, unique } from './standard/index.js';
 
 export { tsf } from './tsf/index.js';


### PR DESCRIPTION
Missed this in #213 